### PR TITLE
add dependecies and commands for snapshot/preconfigured datadir download

### DIFF
--- a/l2geth/Dockerfile
+++ b/l2geth/Dockerfile
@@ -2,6 +2,9 @@ ARG UPSTREAM_VERSION
 
 FROM ethereumoptimism/l2geth:${UPSTREAM_VERSION}
 
+# add curl for downloading snapshot of the required preconfigured datadir for legacy OP L2geth to operate, at https://datadirs.optimism.io/mainnet-legacy-archival.tar.zst
+RUN apk update && apk add curl
+
 # Necessary to avoid errors
 ENV USING_OVM=true
 ENV ETH1_SYNC_SERVICE_ENABLE=false 


### PR DESCRIPTION
Currently this package does not work as its missing a crucial step.  Having any data to serve to the rest of the OP stack.

According to Optimism Docs regarding Legacy [opL2geth](https://docs.optimism.io/builders/node-operators/management/snapshots#op-mainnet-legacy)

this component of the OP stack is optional and only needed for serving up historical traces (which is only required or needed for full archival nodes) from before the Bedrock upgrade.  it is their legacy  binary in a read only setup, it will not sync with any other nodes, seqencers etc, and is simply called upon for historical pre bedrock traces by the rest of the OP stack.  Because this doesn't  sync or change once installed it needs to be initialized with the preconfigured data dir/snapshot available here: https://docs.optimism.io/builders/node-operators/management/snapshots#op-mainnet-legacy

So this PR will fix this component so that it has data to serve, because without this change its about 4MB total never changing for months